### PR TITLE
Remove dangling Notifications route from navigation graph

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
@@ -239,9 +239,6 @@ fun MainScreen(
                         onIntent = { intent -> manageCategoryViewModel.processIntent(intent) }
                     )
                 }
-                composable(Screen.Notifications.route) {
-                    // NotificationsScreen removed for now
-                }
                 composable(
                     route = Screen.Note.route,
                     arguments = listOf(

--- a/app/src/main/java/com/duhapp/dnotes/ui/navigation/Screen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/ui/navigation/Screen.kt
@@ -3,7 +3,6 @@ package com.duhapp.dnotes.ui.navigation
 sealed class Screen(val route: String) {
     data object Home : Screen("home")
     data object ManageCategory : Screen("manage_category")
-    data object Notifications : Screen("notifications")
     data object Note : Screen("note?noteItem={noteItem}") {
         fun createRoute(noteItem: String? = null): String {
             return if (noteItem != null) "note?noteItem=$noteItem" else "note"


### PR DESCRIPTION
### Motivation
- Remove a registered navigation route that had no implemented UI destination so every route maps to a real screen.

### Description
- Removed `Screen.Notifications` from the sealed `Screen` routes and deleted the empty `composable(Screen.Notifications.route)` entry in `MainScreen.kt` so the navigation graph contains only active destinations.

### Testing
- Executed `./gradlew :app:compileDebugKotlin`, which failed in this environment due to Java/Gradle compatibility (`Unsupported class file major version 69`), so the build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50b782eb88325a9845f2a20b55316)