### PR TITLE
Refresh manage category screen after category upsert

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
@@ -94,6 +94,7 @@ fun MainScreen(
 ) {
     val navController = rememberNavController()
     val categoryBottomSheetViewModel: CategoryBottomSheetViewModel = hiltViewModel()
+    val manageCategoryViewModel: ManageCategoryViewModel = hiltViewModel()
 
     var showCategoryBottomSheet by rememberSaveable { mutableStateOf(false) }
     var bottomSheetCategory by rememberSaveable { mutableStateOf(CategoryUIModel()) }
@@ -215,7 +216,6 @@ fun MainScreen(
                     )
                 }
                 composable(Screen.ManageCategory.route) {
-                    val manageCategoryViewModel: ManageCategoryViewModel = hiltViewModel()
                     val state by manageCategoryViewModel.state.collectAsState()
 
                     LaunchedEffect(Unit) {
@@ -326,6 +326,7 @@ fun MainScreen(
             onSave = { savedCategory ->
                 showCategoryBottomSheet = false
                 mainViewModel.loadCategories()
+                manageCategoryViewModel.onCategoryUpserted()
             },
             onDismiss = {
                 showCategoryBottomSheet = false


### PR DESCRIPTION
### Motivation
- The bottom-sheet category editor should update both the global category cache and the active manage-category screen state after an add/edit so UI lists stay consistent.
- Ensure that saving from `CategoryBottomSheetScreen` notifies the same `ManageCategoryViewModel` instance that backs `ManageCategoryScreen` so it can reload categories immediately.

### Description
- Hoisted `ManageCategoryViewModel` into `MainScreen` scope by calling `val manageCategoryViewModel: ManageCategoryViewModel = hiltViewModel()` at the top of `MainScreen` so the VM is available outside the `ManageCategory` destination block.
- Removed the local `hiltViewModel()` call inside the `Screen.ManageCategory` composable and now reuse the hoisted `manageCategoryViewModel` for state and effects.
- Updated `CategoryBottomSheetScreen` `onSave` callback to call both `mainViewModel.loadCategories()` and `manageCategoryViewModel.onCategoryUpserted()` so `MainViewModel.categories` and `ManageCategoryScreenState.categories` are refreshed after upsert.

### Testing
- Ran `./gradlew :app:compileDebugKotlin`, but the build failed due to an environment/toolchain error (`Unsupported class file major version 69`) during Gradle script analysis, so no successful Kotlin compilation was completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50b79d6ec8325a9a4f93bc79d49b6)