### PR TITLE
Add explicit delete control for each category row

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/features/manage_category/ui/ManageCategoryScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/manage_category/ui/ManageCategoryScreen.kt
@@ -16,11 +16,13 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -116,7 +118,8 @@ fun ManageCategoryContent(
                 ) { category ->
                     CategoryListItem(
                         category = category,
-                        onClick = { onCategoryClick(category) }
+                        onClick = { onCategoryClick(category) },
+                        onDeleteClick = { onDeleteCategory(category) }
                     )
                 }
             }
@@ -139,6 +142,7 @@ fun ManageCategoryContent(
 fun CategoryListItem(
     category: CategoryUIModel,
     onClick: () -> Unit,
+    onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val backgroundColor = getCategoryColor(category.color.color.ordinal)
@@ -194,6 +198,16 @@ fun CategoryListItem(
                         modifier = Modifier.padding(top = 4.dp)
                     )
                 }
+            }
+
+            IconButton(
+                onClick = onDeleteClick
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Delete,
+                    contentDescription = "Delete ${category.name}",
+                    tint = Color.White
+                )
             }
         }
     }


### PR DESCRIPTION
### Motivation
- Make category deletion discoverable and directly actionable from the list while preserving the existing tap-to-edit behavior on each row.

### Description
- Added a trailing delete `IconButton` using `Icons.Default.Delete` to each category row in `app/src/main/java/com/duhapp/dnotes/features/manage_category/ui/ManageCategoryScreen.kt`.
- Propagated a new `onDeleteClick` parameter from `CategoryListItem` through `ManageCategoryContent` to call the existing `onDeleteCategory(category)` callback which is already mapped to `ManageCategoryScreenIntent.DeleteCategory(category)`.
- Kept the `Card` row `onClick` intact so tapping a row still triggers edit behavior.
- Added the required imports for `Icons.Default.Delete` and `IconButton` and updated the item rendering to pass the delete action.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` to validate Kotlin compilation, which failed in this environment due to a JDK/Gradle class version mismatch (`Unsupported class file major version 69`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50b7600f483258b8c3f94b9fe0749)