### PR TITLE
Support long-click on AllNotes note cards using combinedClickable

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt
@@ -2,7 +2,7 @@ package com.duhapp.dnotes.features.all_notes.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -184,7 +184,10 @@ fun AllNotesNoteItem(
     Card(
         modifier = modifier
             .width(180.dp)
-            .clickable(onClick = onClick)
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = onLongClick
+            )
             .then(
                 if (isSelected) {
                     Modifier.border(2.dp, Color.Blue, RoundedCornerShape(12.dp))


### PR DESCRIPTION
### Motivation
- Enable note cards to handle long-press input so the UI can enter selection mode by wiring the card UI to the existing `AllNotesScreenIntent.NoteLongClicked` and selection state.

### Description
- Replaced `Modifier.clickable` with `Modifier.combinedClickable` (import and usage) and updated the `Card` modifier in `AllNotesNoteItem` to use `.combinedClickable(onClick = onClick, onLongClick = onLongClick)` while preserving the existing selection border logic.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` which failed in this environment due to a Gradle/JDK incompatibility (`Unsupported class file major version 69`), so automated build verification could not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50b35549c83258aeeee388ede01b2)