### PR TITLE
Initialize default category at startup to fix note save visibility

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/MainActivity.kt
+++ b/app/src/main/java/com/duhapp/dnotes/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
@@ -13,9 +14,12 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+    private val mainActivityViewModel: MainActivityViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        mainActivityViewModel.initializeDefaultDataModels()
         setContent {
             DNotesTheme {
                 Surface(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/ui/MainScreen.kt
@@ -54,6 +54,7 @@ import com.duhapp.dnotes.features.home.ui.HomeScreenEffect
 import com.duhapp.dnotes.features.home.ui.HomeScreenIntent
 import com.duhapp.dnotes.features.home.ui.HomeViewModel
 import com.duhapp.dnotes.features.home.home_screen_category.ui.BaseNoteUIModel
+import com.duhapp.dnotes.features.manage_category.domain.CreateDefaultCategory
 import com.duhapp.dnotes.features.manage_category.ui.ManageCategoryScreen
 import com.duhapp.dnotes.features.manage_category.ui.ManageCategoryScreenEffect
 import com.duhapp.dnotes.features.manage_category.ui.ManageCategoryViewModel
@@ -79,7 +80,8 @@ data class BottomNavItem(
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val getCategories: GetCategories
+    private val getCategories: GetCategories,
+    private val createDefaultCategory: CreateDefaultCategory
 ) : ViewModel() {
     var categories by mutableStateOf<List<CategoryUIModel>>(emptyList())
         private set
@@ -90,6 +92,7 @@ class MainViewModel @Inject constructor(
 
     fun loadCategories() {
         viewModelScope.launch {
+            createDefaultCategory.invoke()
             categories = getCategories.invoke()
         }
     }


### PR DESCRIPTION
### Motivation
- Ensure the app creates the default category before any category/note reads so notes saved into the default category are visible and not lost due to a missing category at startup.

### Description
- Wire `MainActivityViewModel` into `MainActivity` and call `initializeDefaultDataModels()` on startup, and update `MainViewModel` to call `createDefaultCategory.invoke()` before loading categories to guarantee the default category exists.

### Testing
- Ran unit test command `./gradlew testDebugUnitTest --no-daemon`, which failed to start due to the environment error `Unsupported class file major version 69` before tests could execute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c54bce81d48325bc74137ccb3255fa)