### PR TITLE
Keep home notes grouped by category with fixed card sizing

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
@@ -34,6 +34,10 @@ import com.duhapp.dnotes.features.home.home_screen_category.ui.HomeCategoryUIMod
 import com.duhapp.dnotes.ui.theme.BackgroundColor
 import com.duhapp.dnotes.ui.theme.PrimaryColor
 
+private val HomeNoteCardWidth = 180.dp
+private val HomeNoteCardHeight = 252.dp
+private val HomeCategorySpacing = 16.dp
+
 @Composable
 fun HomeScreen(
     state: HomeScreenState,
@@ -149,9 +153,12 @@ fun HomeCategorySection(
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
             contentPadding = PaddingValues(top = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+            horizontalArrangement = Arrangement.spacedBy(HomeCategorySpacing)
         ) {
-            items(category.noteList) { note ->
+            items(
+                items = category.noteList,
+                key = { note -> note.id }
+            ) { note ->
                 if (note is BasicNoteUIModel) {
                     NoteListItem(
                         note = note,
@@ -174,8 +181,8 @@ fun NoteListItem(
 
     Card(
         modifier = modifier
-            .width(180.dp)
-            .height(252.dp)
+            .width(HomeNoteCardWidth)
+            .height(HomeNoteCardHeight)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)


### PR DESCRIPTION
### Motivation
- Preserve the category-separated, horizontally scrollable home screen while enforcing a stable width/height for each note card so main-screen notes render with consistent size.

### Description
- Introduced `HomeNoteCardWidth`, `HomeNoteCardHeight`, and `HomeCategorySpacing` and updated `app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt` to use these constants and added a stable `key = { note.id }` to the `LazyRow` `items` call.

### Testing
- Ran `./gradlew :app:assembleDebug` which failed in this environment due to a Java/Gradle incompatibility (`Unsupported class file major version 69`) so no successful build verification was possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c583e248308325985981401b81c68a)