### PR TITLE
Replace LazyColumn/LazyRow with scrollable Column/Row and extract layout constants

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
@@ -5,16 +5,15 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -33,6 +32,10 @@ import com.duhapp.dnotes.features.home.home_screen_category.ui.BasicNoteUIModel
 import com.duhapp.dnotes.features.home.home_screen_category.ui.HomeCategoryUIModel
 import com.duhapp.dnotes.ui.theme.BackgroundColor
 import com.duhapp.dnotes.ui.theme.PrimaryColor
+
+private val HomeNoteCardWidth = 180.dp
+private val HomeNoteCardHeight = 252.dp
+private val HomeCategorySpacing = 16.dp
 
 @Composable
 fun HomeScreen(
@@ -100,15 +103,15 @@ fun HomeContent(
             )
         }
     } else {
-        LazyColumn(
+        Column(
             modifier = modifier
                 .fillMaxSize()
                 .background(BackgroundColor)
-                .padding(horizontal = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp),
-            contentPadding = PaddingValues(top = 24.dp, bottom = 16.dp)
+                .verticalScroll(rememberScrollState())
+                .padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(20.dp)
         ) {
-            items(categories) { category ->
+            categories.forEach { category ->
                 HomeCategorySection(
                     category = category,
                     onNoteClick = onNoteClick,
@@ -146,12 +149,15 @@ fun HomeCategorySection(
             )
         }
 
-        LazyRow(
-            modifier = Modifier.fillMaxWidth(),
-            contentPadding = PaddingValues(top = 12.dp),
-            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .padding(top = 12.dp),
+            verticalAlignment = Alignment.Top,
+            horizontalArrangement = Arrangement.spacedBy(HomeCategorySpacing)
         ) {
-            items(category.noteList) { note ->
+            category.noteList.forEach { note ->
                 if (note is BasicNoteUIModel) {
                     NoteListItem(
                         note = note,
@@ -174,8 +180,8 @@ fun NoteListItem(
 
     Card(
         modifier = modifier
-            .width(180.dp)
-            .height(252.dp)
+            .width(HomeNoteCardWidth)
+            .height(HomeNoteCardHeight)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)


### PR DESCRIPTION
### Motivation
- Simplify Home screen layout and enable straightforward scrolling of category sections and their note lists by switching from lazy composables to scrollable containers.
- Standardize note card sizing and category spacing to make layout values reusable and consistent across the UI.

### Description
- Replaced `LazyColumn` with a `Column` combined with `verticalScroll(rememberScrollState())` and adjusted padding to `start/end/top/bottom` values.
- Replaced `LazyRow` with a `Row` combined with `horizontalScroll(rememberScrollState())`, used `Arrangement.spacedBy(HomeCategorySpacing)`, and converted `items(...)` usage to `forEach` for rendering notes.
- Introduced layout constants `HomeNoteCardWidth`, `HomeNoteCardHeight`, and `HomeCategorySpacing` and applied them to `NoteListItem` sizing and spacing.
- Updated imports to remove lazy list APIs and add scroll-related APIs and cleaned up related code accordingly.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c583e248308325985981401b81c68a)