### PR TITLE
Responsive View All: fixed-width note cards with max-height and dynamic wrapping

### DIFF
--- a/app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -46,6 +48,10 @@ import androidx.compose.ui.unit.sp
 import com.duhapp.dnotes.features.home.home_screen_category.ui.BasicNoteUIModel
 import com.duhapp.dnotes.ui.theme.BackgroundColor
 import com.duhapp.dnotes.ui.theme.PrimaryColor
+
+private val AllNotesCardWidth = 180.dp
+private val AllNotesCardMaxHeight = 252.dp
+private val AllNotesGridSpacing = 16.dp
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -129,34 +135,42 @@ fun AllNotesScreen(
                         Text("No notes found")
                     }
                 } else {
-                    FlowRow(
+                    BoxWithConstraints(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                            .padding(16.dp)
                     ) {
-                        state.notes.filterIsInstance<BasicNoteUIModel>().forEach { note ->
-                            AllNotesNoteItem(
-                                note = note,
-                                isSelectable = state.isSelectable,
-                                isSelected = state.selectedNoteIds.contains(note.id),
-                                onClick = {
-                                    onIntent(AllNotesScreenIntent.NoteClicked(note))
-                                },
-                                onLongClick = {
-                                    onIntent(AllNotesScreenIntent.NoteLongClicked(note))
-                                },
-                                onEdit = {
-                                    onIntent(AllNotesScreenIntent.NoteClicked(note))
-                                },
-                                onDelete = {
-                                    onIntent(AllNotesScreenIntent.DeleteNote(note))
-                                },
-                                onMove = {
-                                    onIntent(AllNotesScreenIntent.MoveNote(note))
-                                }
-                            )
+                        val maxItemsInRow = ((maxWidth + AllNotesGridSpacing) / (AllNotesCardWidth + AllNotesGridSpacing))
+                            .toInt()
+                            .coerceAtLeast(1)
+
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(AllNotesGridSpacing),
+                            verticalArrangement = Arrangement.spacedBy(AllNotesGridSpacing),
+                            maxItemsInEachRow = maxItemsInRow
+                        ) {
+                            state.notes.filterIsInstance<BasicNoteUIModel>().forEach { note ->
+                                AllNotesNoteItem(
+                                    note = note,
+                                    isSelectable = state.isSelectable,
+                                    isSelected = state.selectedNoteIds.contains(note.id),
+                                    onClick = {
+                                        onIntent(AllNotesScreenIntent.NoteClicked(note))
+                                    },
+                                    onLongClick = {
+                                        onIntent(AllNotesScreenIntent.NoteLongClicked(note))
+                                    },
+                                    onEdit = {
+                                        onIntent(AllNotesScreenIntent.NoteClicked(note))
+                                    },
+                                    onDelete = {
+                                        onIntent(AllNotesScreenIntent.DeleteNote(note))
+                                    },
+                                    onMove = {
+                                        onIntent(AllNotesScreenIntent.MoveNote(note))
+                                    }
+                                )
+                            }
                         }
                     }
                 }
@@ -184,7 +198,8 @@ fun AllNotesNoteItem(
 
     Card(
         modifier = modifier
-            .width(180.dp)
+            .width(AllNotesCardWidth)
+            .heightIn(max = AllNotesCardMaxHeight)
             .combinedClickable(
                 onClick = onClick,
                 onLongClick = onLongClick

--- a/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
+++ b/app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -36,7 +37,7 @@ import com.duhapp.dnotes.ui.theme.BackgroundColor
 import com.duhapp.dnotes.ui.theme.PrimaryColor
 
 private val HomeNoteCardWidth = 180.dp
-private val HomeNoteCardHeight = 252.dp
+private val HomeNoteCardMaxHeight = 252.dp
 private val HomeCategorySpacing = 16.dp
 
 @Composable
@@ -183,7 +184,7 @@ fun NoteListItem(
     Card(
         modifier = modifier
             .width(HomeNoteCardWidth)
-            .height(HomeNoteCardHeight)
+            .heightIn(max = HomeNoteCardMaxHeight)
             .clickable(onClick = onClick),
         colors = CardDefaults.cardColors(containerColor = backgroundColor),
         elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)


### PR DESCRIPTION
### Motivation
- Make the "View All" notes screen adapt to different screen widths so multiple note cards can sit side-by-side as space allows while keeping a consistent card width. 
- Allow note card height to grow naturally up to a limit instead of being hard-fixed so cards don't overflow content but remain visually consistent across screens.

### Description
- Replaced fixed card heights with a maximum height by using `heightIn(max = ...)` for note cards in `HomeScreen.kt` and `AllNotesScreen.kt` so cards can size up to `252.dp` instead of a fixed height. 
- Kept a fixed card width of `180.dp` and introduced constants `AllNotesCardWidth`, `AllNotesCardMaxHeight`, and `AllNotesGridSpacing` in `app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt`. 
- Made the View All layout responsive by wrapping the grid in `BoxWithConstraints`, computing `maxItemsInRow` from `maxWidth`, and passing it to `FlowRow(maxItemsInEachRow = ...)` so items wrap to the next row based on available width. 
- Added necessary imports (`BoxWithConstraints`, `heightIn`) and updated `NoteListItem`/`AllNotesNoteItem` modifiers to use the new width/height constraints; files changed: `app/src/main/java/com/duhapp/dnotes/features/all_notes/ui/AllNotesScreen.kt` and `app/src/main/java/com/duhapp/dnotes/features/home/ui/HomeScreen.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the build failed due to an environment Java/Gradle compatibility error: `Unsupported class file major version 69`.
- No other automated tests were run in this environment due to the compilation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c58e5bf22c8325b31d4adcd9c3476e)